### PR TITLE
Added new "get" resources when ODF (former OCS) is installed on cluster

### DIFF
--- a/omg/cmd/get/cephblockpools_out.py
+++ b/omg/cmd/get/cephblockpools_out.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+from tabulate import tabulate
+
+from omg.common.helper import age, extract_labels
+
+
+def cephblockpools_out(t, ns, res, output, show_type, show_labels):
+    output_res = [[]]
+    # header
+    if ns == "_all":
+        output_res[0].append("NAMESPACE")
+    if show_labels:
+        output_res[0].extend(["NAME", "AGE", "LABELS"])
+    else:
+        output_res[0].extend(["NAME", "AGE"])
+
+    # resources
+    for r in res:
+        cf = r["res"]
+        row = []
+        # namespace (for --all-namespaces)
+        if ns == "_all":
+            row.append(cf["metadata"]["namespace"])
+        # name
+        if show_type:
+            row.append(t + "/" + cf["metadata"]["name"])
+        else:
+            row.append(cf["metadata"]["name"])
+        # age
+        try:
+            ct = str(cf["metadata"]["creationTimestamp"])
+            ts = r["gen_ts"]
+            row.append(age(ct, ts))
+        except:
+            row.append("Unknown")
+
+        if show_labels:
+            row.append(extract_labels(cf))
+
+        output_res.append(row)
+
+    print(tabulate(output_res, tablefmt="plain"))

--- a/omg/cmd/get/cephobjectstoreusers_out.py
+++ b/omg/cmd/get/cephobjectstoreusers_out.py
@@ -9,7 +9,7 @@ def cephobjectstoreusers_out(t, ns, res, output, show_type, show_labels):
     # header
     header = []
     if ns == "_all":
-        header.append("NAMESPACE")
+        output_res[0].append("NAMESPACE")
     if show_labels:
         output_res[0].extend(["NAME", "AGE", "LABELS"])
     else:

--- a/omg/common/resource_map.py
+++ b/omg/common/resource_map.py
@@ -3,6 +3,7 @@ import os
 
 from omg.cmd.get.bc_out import bc_out
 from omg.cmd.get.build_out import build_out
+from omg.cmd.get.cephblockpools_out import cephblockpools_out
 from omg.cmd.get.cephclusters_out import cephclusters_out
 from omg.cmd.get.cephfilesystems_out import cephfilesystems_out
 from omg.cmd.get.cephobjectstores_out import cephobjectstores_out
@@ -88,6 +89,14 @@ map = [
         "get_func": from_yaml,
         "getout_func": bc_out,
         "yaml_loc": "namespaces/%s/build.openshift.io/buildconfigs.yaml",
+    },
+    {
+        "type": "cephblockpools",
+        "aliases": ["cephblockpools"],
+        "need_ns": True,
+        "get_func": from_yaml,
+        "getout_func": cephblockpools_out,
+        "yaml_loc": "ceph/namespaces/%s/ceph.rook.io/cephblockpools",
     },
     {
         "type": "cephclusters",


### PR DESCRIPTION
```
$ omg get volumeattachments 
NAME                                                                  ATTACHER                            PV                                        NODE                   ATTACHED  AGE
csi-53e56f4c95184bf973b2437bdb518ae3dfafe23952c2e50d067e60b2aa0309ed  openshift-storage.rbd.csi.ceph.com  pvc-89ef98f8-6bd8-4028-a7b0-4a0e0130ac1f  brcsfpadvop4wor-qz4j4  True      9d
..
<output ommited>

$ omg get csidrivers
NAME                                   ATTACHREQUIRED  PODINFOONMOUNT  MODES       AGE
openshift-storage.cephfs.csi.ceph.com  True            False           Persistent  61d
openshift-storage.rbd.csi.ceph.com     True            False           Persistent  61d

$ omg get csinodes 
NAME                                                DRIVERS  AGE
brcsfpadvop4dev-2mltd                               2        19d
brcsfpadvop4dev-r2qd7                               2        19d
brcsfpadvop4inf-92trj                               2        61d
..
<output ommited>

$ omg get cephclusters -A --show-labels
NAMESPACE          NAME                            DATADIRHOSTPATH  MONCOUNT  AGE  PHASE  MESSAGE                       HEALTH       LABELS
openshift-storage  ocs-storagecluster-cephcluster  /var/lib/rook    3         61d  Ready  Cluster created successfully  HEALTH_WARN  app=ocs-storagecluster

$ omg get cephblockpools -A
NAMESPACE          NAME                              AGE
openshift-storage  ocs-storagecluster-cephblockpool  61d

$ omg get cephfilesystems -A --show-labels
NAMESPACE          NAME                               ACTIVEMDS  AGE  LABELS
openshift-storage  ocs-storagecluster-cephfilesystem  1          61d  ceph_version=14.2.11-147-nautilus

$ omg get cephobjectstores -A --show-labels
NAMESPACE          NAME                                AGE  LABELS
openshift-storage  ocs-storagecluster-cephobjectstore  61d  ceph_version=14.2.11-147-nautilus

```